### PR TITLE
docs: expand hardware smoke matrix for new integrated tools

### DIFF
--- a/docs/HARDWARE_SMOKE_LOG.md
+++ b/docs/HARDWARE_SMOKE_LOG.md
@@ -30,18 +30,18 @@ Use alongside:
 | `vector_face` |  |  |  |
 | `vector_head` |  |  |  |
 | `vector_lift` |  |  |  |
-| `vector_scan` |  |  |  |
-| `vector_find_faces` |  |  |  |
-| `vector_list_visible_faces` |  |  |  |
-| `vector_list_visible_objects` |  |  |  |
-| `vector_drive_on_charger` |  |  |  |
-| `vector_emergency_stop` |  |  |  |
-| `vector_capture_image` |  |  |  |
-| `vector_face_detection` |  |  |  |
-| `vector_vision_reset` |  |  |  |
-| `vector_charger_status` |  |  |  |
-| `vector_touch_status` |  |  |  |
-| `vector_proximity_status` |  |  |  |
+| `vector_scan` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_find_faces` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_list_visible_faces` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_list_visible_objects` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_drive_on_charger` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_emergency_stop` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_capture_image` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_face_detection` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_vision_reset` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_charger_status` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_touch_status` |  |  | Pending MCP registration (#67) — skip until integrated |
+| `vector_proximity_status` |  |  | Pending MCP registration (#67) — skip until integrated |
 
 ### Anomalies / Follow-ups
 - 

--- a/docs/HARDWARE_TEST_PLAYBOOK.md
+++ b/docs/HARDWARE_TEST_PLAYBOOK.md
@@ -6,7 +6,7 @@ Repeatable, low-ambiguity on-robot validation protocol for VectorClaw.
 >
 > **Running records:** [Hardware Smoke Log](HARDWARE_SMOKE_LOG.md) and [Tool Docking Prerequisites](TOOL_DOCKING_PREREQUISITES.md).
 >
-> **Post-integration add-on:** After integration-wiring PRs merge, run the expanded matrix in `HARDWARE_SMOKE_LOG.md` (new tools: scan/find/list, charger+sensors, vision controls, emergency/motion helpers).
+> **Post-integration add-on:** Run the expanded matrix in `HARDWARE_SMOKE_LOG.md` only after issue #67 (tool registration integration) is merged. Skip any rows still marked as pending registration.
 
 ---
 


### PR DESCRIPTION
Adds post-integration smoke entries for newly registered tools and links the expanded matrix from the hardware playbook.