### PR TITLE
docs: add onboarding quickstart for first-time setup

### DIFF
--- a/docs/ONBOARDING_QUICKSTART.md
+++ b/docs/ONBOARDING_QUICKSTART.md
@@ -9,25 +9,30 @@ Get a first-time user to a working VectorClaw MCP setup quickly and safely.
 - OpenClaw environment ready
 - Vector serial available
 
-## 1) Install SDK
+## 1) Install SDK (pinned)
 ```bash
-pip install git+https://github.com/kercre123/wirepod-vector-python-sdk.git
+pip install git+https://github.com/kercre123/wirepod-vector-python-sdk.git@065fc197d592d76a164d64dcf0a768183ab37855
 ```
 
 ## 2) Set required env
 ```bash
-export VECTOR_SERIAL=<your-vector-serial>
+export VECTOR_SERIAL="YOUR_VECTOR_SERIAL"
 # optional:
-export VECTOR_HOST=<robot-ip-or-host>
+export VECTOR_HOST="ROBOT_IP_OR_HOST"
 ```
 
-## 3) Verify import
+## 3) One-time SDK auth/config
+```bash
+python -m anki_vector.configure --serial "$VECTOR_SERIAL"
+```
+
+## 4) Verify import
 ```bash
 python -c "import anki_vector; print('anki_vector import ok')"
 ```
 
-## 4) Run baseline smoke
-Run tools in this order and verify physical behavior where applicable:
+## 5) Run baseline smoke
+Run these via your MCP client/OpenClaw integration (see `docs/API_REFERENCE.md` for tool contracts):
 1. `vector_status`
 2. `vector_say`
 3. `vector_drive_off_charger`
@@ -36,8 +41,8 @@ Run tools in this order and verify physical behavior where applicable:
 6. `vector_head`
 7. `vector_lift`
 
-## 5) If something fails
-See `docs/TROUBLESHOOTING.md` and capture:
+## 6) If something fails
+See [Troubleshooting](SETUP.md#troubleshooting) and capture:
 - command
 - exact error text
 - observed robot behavior


### PR DESCRIPTION
Adds a concise 5-minute setup path from SDK install to baseline smoke validation for new users.