### PR TITLE
docs: post-integration alignment pass (remove stale #67 pending text)

### DIFF
--- a/docs/HARDWARE_TEST_PLAYBOOK.md
+++ b/docs/HARDWARE_TEST_PLAYBOOK.md
@@ -6,7 +6,7 @@ Repeatable, low-ambiguity on-robot validation protocol for VectorClaw.
 >
 > **Running records:** [Hardware Smoke Log](HARDWARE_SMOKE_LOG.md) and [Tool Docking Prerequisites](TOOL_DOCKING_PREREQUISITES.md).
 >
-> **Post-integration add-on:** Run the expanded matrix in `HARDWARE_SMOKE_LOG.md` only after issue #67 (tool registration integration) is merged. Skip any rows still marked as pending registration.
+> **Post-integration add-on:** Issue #67 (tool registration integration) is merged. Run the expanded matrix in `HARDWARE_SMOKE_LOG.md` for the newly registered tools before release cut.
 
 ---
 

--- a/docs/RELEASE_NOTES_V1_RC_DRAFT.md
+++ b/docs/RELEASE_NOTES_V1_RC_DRAFT.md
@@ -7,7 +7,7 @@
 - Runtime/tool registration architecture split for lower merge-conflict risk
 - Hardware smoke validation process standardized
 
-## New Capability Areas (implemented; MCP exposure pending #67)
+## New Capability Areas (implemented and MCP-registered)
 
 ### Perception Discovery
 - `vector_scan`
@@ -40,7 +40,7 @@
 
 ## Validation
 - CI matrix: Python 3.11 + 3.12 experimental
-- Hardware smoke: baseline command set validated; expanded matrix pending post-integration run
+- Hardware smoke: baseline command set validated; expanded matrix execution in progress for newly registered tools
 
 ## Upgrade Notes
 - Existing users should review updated API docs for new tool registrations and payload shapes


### PR DESCRIPTION
Final docs alignment pass:\n- remove stale 'pending #67' wording now that integration is merged\n- update release-note phrasing to reflect MCP registration status\n- keep hardware expanded-matrix callout focused on pre-release execution