### PR TITLE
docs: align SDK docs with runtime-observed schema evidence (#85)

### DIFF
--- a/docs/SDK_TO_MCP_COVERAGE_MATRIX.md
+++ b/docs/SDK_TO_MCP_COVERAGE_MATRIX.md
@@ -2,14 +2,18 @@
 
 Status legend:
 - ✅ Implemented + validated on hardware
-- 🟡 Implemented, pending full hardware validation
+- 🟡 Implemented, pending full hardware validation or reliability follow-up
 - ⚪ Not implemented yet
+
+Runtime note:
+- This matrix reflects both source-level implementation and runtime-observed behavior.
+- If source assumptions conflict with runtime object shape, runtime evidence governs tool-contract decisions.
 
 ## Current MCP Tool Coverage
 
 | Capability | Tool | Implementation | Hardware validation | Notes |
 |---|---|---:|---:|---|
-| Robot status | `vector_status` | ✅ | ✅ | Battery/charging/carrying-block verified |
+| Robot status | `vector_status` | ✅ | ✅ | Runtime-variance handled in current path; stable-key contract documented |
 | Robot pose | `vector_pose` | ✅ | ✅ | Position/orientation payload returned |
 | Camera capture | `vector_look` | ✅ | ✅ | Base64 image returned |
 | Speech | `vector_say` | ✅ | ✅ | Audible speech confirmed |
@@ -21,17 +25,17 @@ Status legend:
 | Head motion | `vector_head` | ✅ | 🟡 | Clamped to -22.0–45.0 degrees |
 | Lift/arm motion | `vector_lift` | ✅ | 🟡 | Normalised 0.0–1.0 range |
 | Scan environment | `vector_scan` | ✅ | 🟡 | look_around_in_place behavior |
-| Find faces | `vector_find_faces` | ✅ | 🟡 | Active face search behavior |
-| List visible faces | `vector_list_visible_faces` | ✅ | 🟡 | Returns face_id and name |
-| List visible objects | `vector_list_visible_objects` | ✅ | 🟡 | Returns object_id list |
-| Drive on charger | `vector_drive_on_charger` | ✅ | 🟡 | Timeout + motor-stop fallback |
+| Find faces | `vector_find_faces` | ✅ | 🟡 | Behavior triggers correctly; semantics differ from detection query path |
+| List visible faces | `vector_list_visible_faces` | ✅ | 🟡 | Functional path; often empty in runtime trials |
+| List visible objects | `vector_list_visible_objects` | ✅ | 🟡 | Functional path; often empty under expected conditions (issue #87/#89) |
+| Drive on charger | `vector_drive_on_charger` | ✅ | 🟡 | Tool returns ok, but hardware behavior mismatch under test (issue #88) |
 | Emergency stop | `vector_emergency_stop` | ✅ | 🟡 | Stops all motors immediately |
 | Capture single image | `vector_capture_image` | ✅ | 🟡 | Via capture_single_image |
 | Face detection summary | `vector_face_detection` | ✅ | 🟡 | Returns face_count + expression |
 | Vision reset | `vector_vision_reset` | ✅ | 🟡 | Disables all vision modes |
-| Charger state | `vector_charger_status` | ✅ | 🟡 | Charging + battery + platform |
-| Touch sensor | `vector_touch_status` | ✅ | 🟡 | is_being_touched + raw_touch_value |
-| Proximity sensor | `vector_proximity_status` | ✅ | 🟡 | distance_mm + found_object + is_lift_in_fov |
+| Charger state | `vector_charger_status` | ✅ | 🟡 | Current runtime mismatch on `is_on_charger_platform` assumption (issue #90) |
+| Touch sensor | `vector_touch_status` | ✅ | ✅ | False→true transition validated on hardware |
+| Proximity sensor | `vector_proximity_status` | ✅ | ✅ | Distance response validated; `found_object` semantics under investigation (#91) |
 
 ## Validation Protocol (recommended)
 

--- a/docs/WIREPOD_SDK_IMPLEMENTATION_GUIDE.md
+++ b/docs/WIREPOD_SDK_IMPLEMENTATION_GUIDE.md
@@ -106,8 +106,27 @@ robot.connect()
 ## Known compatibility notes
 
 1. `wirepod_vector_sdk` installs under the `anki_vector` namespace.
-2. Modern Python compatibility may require SDK fork patches (see `SDK_PATCH_NOTES.md`).
+2. Runtime object fields may differ from source assumptions (validate on hardware/runtime, not docs alone).
 3. Charger preconditions should be handled explicitly for movement reliability.
+
+## Stable external status contract (VectorClaw guidance)
+
+For `vector_status` and `vector_charger_status`, implement a stable external payload contract and document nullable keys explicitly.
+
+Recommended contract keys:
+- `status`
+- `battery_level`
+- `is_charging`
+- `is_carrying_block`
+- `is_carrying_object` *(nullable if runtime field absent)*
+- `is_on_charger_platform` *(nullable if runtime field absent)*
+- `is_cliff_detected` *(nullable if runtime field absent)*
+- `is_picked_up` *(nullable if runtime field absent)*
+
+Implementation rule:
+- Use authoritative runtime-verified fields first.
+- Do not assume parity with source-derived names.
+- If a field is unavailable in runtime, return explicit `null` (or defined default) instead of throwing.
 
 ## Scope rule
 

--- a/docs/WIREPOD_SDK_SURFACE_REFERENCE.md
+++ b/docs/WIREPOD_SDK_SURFACE_REFERENCE.md
@@ -13,6 +13,35 @@ _Generated from source on 2026-02-27T08:16:58_
 - **Signature** is source-derived and shows arguments/defaults/type hints when present.
 - **Description/Args/Returns** are extracted from SDK docstrings when available.
 
+## Runtime-observed schema notes (hardware smoke, 2026-02-27)
+
+Source-derived SDK surfaces are necessary but not sufficient: runtime objects can differ from assumed attributes.
+
+### RobotStatus (runtime-observed)
+
+| Field | Runtime observation | Notes |
+|---|---|---|
+| `is_charging` | Present | Safe to use directly |
+| `is_carrying_block` | Present | Safe to use directly |
+| `is_cliff_detected` | Present | Observed in status payload |
+| `is_picked_up` | Present | Observed true when robot held |
+| `is_carrying_object` | Missing in tested runtime | Prior assumption caused `vector_status` failure before hotfix |
+| `is_on_charger_platform` | Missing in tested runtime | Causes `vector_charger_status` failure in current implementation |
+
+### Perception query payload reliability
+
+| Surface | Runtime observation | Notes |
+|---|---|---|
+| Face query results | Often empty (`faces: []`) even in favorable conditions | See issue #89 |
+| Visible object query results | Often empty despite nearby cube in some trials | See issue #87 |
+| Proximity fields | Distance updates reliably; `found_object` may remain false | Investigate semantics in #91 |
+
+### Contract guidance
+
+- Treat this document as **source capability inventory**.
+- For implementation safety, always cross-check with runtime-observed schema and hardware smoke logs.
+- VectorClaw must expose a stable external contract even when runtime fields vary (explicit null/default semantics in MCP layer).
+
 ## Robot component access map (common MCP entry points)
 - `robot.behavior.<method>(...)` → behavior actions (speech, drive, pose-goal, charger, cube interactions)
 - `robot.world.<method>(...)` → world/cube/faces/object visibility and charger object access


### PR DESCRIPTION
## Summary
- add runtime-observed schema notes to SDK surface reference
- document RobotStatus field variance seen in hardware smoke
- add stable external status contract guidance (nullable semantics)
- update coverage matrix notes to reflect runtime evidence and follow-up issues

## Why
Post-integration smoke showed source-level assumptions can differ from runtime object shape. This PR makes that distinction explicit in docs and reduces future contract drift.

## Validation
- docs-only changes
- references aligned with hardware smoke observations logged in HARDWARE_SMOKE_LOG.md

Closes #85