### PR TITLE
docs: codify Unknown Event warning triage and tracking (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All core tools verified **PASS** on a production Vector robot with Wire-Pod:
 
 **Known open issues:**
 - `vector_face` — payload-format bug ([#41](https://github.com/danmartinez78/VectorClaw/issues/41)), fix in progress
-- Non-fatal SDK `Unknown Event type` warning ([#39](https://github.com/danmartinez78/VectorClaw/issues/39)) — non-blocking
+- Non-fatal SDK `Unknown Event type` warning ([#86](https://github.com/danmartinez78/VectorClaw/issues/86), context in [#39](https://github.com/danmartinez78/VectorClaw/issues/39)) — non-blocking
 
 → [ROADMAP.md](ROADMAP.md) for the full v1.0 milestone plan.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -10,8 +10,13 @@
 
 ### 1) `Unknown Event type` warnings in logs
 - **Symptom:** repeated `events.EventHandler WARNING Unknown Event type`
-- **Impact:** currently non-fatal in observed runs
-- **Action:** continue if tools are functioning; track in issue #39 for cleanup
+- **Impact:** currently non-fatal in observed MCP/hardware runs (tools still return `status: ok`)
+- **Primary tracking:** issue #86 (observability investigation)
+- **Related context:** issue #39 (historical warning thread)
+- **Action now:**
+  1. Verify tool behavior first (don’t fail solely on this warning)
+  2. Capture the command + full warning snippet for issue comments
+  3. Treat as blocking only if accompanied by tool failures, disconnect loops, or missing behavior
 
 ### 2) `vector_face` fails with expected byte-length error
 - **Symptom:** `set_screen_with_image_data expected 35328 bytes`


### PR DESCRIPTION
## Summary
- expand troubleshooting guidance for Unknown Event type warnings
- document severity/triage flow (non-blocking unless paired with functional failures)
- align README known-issue link to active investigation (#86) with #39 context

## Why
Hardware smoke shows these warnings are noisy but usually non-fatal. We need consistent operator guidance and tracking so logs remain actionable.

## Validation
- docs-only change
- guidance matches observed MCP hardware behavior from smoke logs

Closes #86