### PR TITLE
docs: define visible_objects snapshot behavior and operator guidance (#87)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -307,9 +307,20 @@ Return the list of objects currently visible to Vector.
 **Output fields:**
 - `objects` (array of `{object_id}` objects)
 
-**Example response:**
+**Semantics and expectations:**
+- This tool is a **snapshot query** of `robot.world.visible_objects` at call time.
+- `status: "ok"` with `objects: []` is a valid result and does **not** imply tool failure.
+- For more deterministic non-empty results, run an active perception behavior before querying (for example `vector_scan`, then re-query).
+- Object visibility depends on runtime conditions (line-of-sight, distance, lighting, angle, and current world-state freshness).
+
+**Example response (objects found):**
 ```json
 {"status": "ok", "objects": [{"object_id": 42}]}
+```
+
+**Example response (no objects in snapshot):**
+```json
+{"status": "ok", "objects": []}
 ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,20 +13,29 @@
 - **Impact:** currently non-fatal in observed runs
 - **Action:** continue if tools are functioning; track in issue #39 for cleanup
 
-### 2) `vector_face` fails with expected byte-length error
+### 2) `vector_list_visible_objects` returns empty list unexpectedly
+- **Symptom:** `{"status": "ok", "objects": []}` even with a nearby object/cube
+- **Impact:** usually a perception-state/timing issue, not a hard MCP failure
+- **Action:**
+  1. Run `vector_scan` to refresh the scene
+  2. Re-run `vector_list_visible_objects`
+  3. Verify line-of-sight, distance, lighting, and object angle
+- **Tracking:** issue #87
+
+### 3) `vector_face` fails with expected byte-length error
 - **Symptom:** `set_screen_with_image_data expected 35328 bytes`
 - **Cause:** payload format mismatch (compressed bytes vs expected raw screen format)
 - **Status:** tracked in issue #41
 - **Workaround:** avoid `vector_face` for release smoke until fixed
 
-### 3) Robot won’t connect
+### 4) Robot won’t connect
 - **Check:**
   - `VECTOR_SERIAL` present
   - network path to robot/Wire-Pod is valid
   - SDK import works in current Python env
 - **Action:** re-run setup flow and verify cert/runtime context
 
-### 4) Contributor-only: merge conflict fallout in perception tests
+### 5) Contributor-only: merge conflict fallout in perception tests
 - **Symptom:** CI fails unexpectedly after conflict resolution
 - **Cause:** stale conflict markers or broken assertions
 - **Action:**


### PR DESCRIPTION
## Summary
- clarify vector_list_visible_objects as a snapshot query at call time
- document that status ok + empty list is valid (not tool failure)
- add deterministic operator guidance (run vector_scan then re-query)
- add troubleshooting entry for empty visible-object snapshots

## Why
Hardware smoke observed frequent empty object lists even with nearby objects. This PR defines expected behavior so users can distinguish tool health from perception-state timing.

## Validation
- docs-only changes
- guidance aligned to runtime smoke observations

Closes #87