### PR TITLE
docs: align status tools with authoritative SDK RobotStatus contract (#90)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -96,10 +96,10 @@ Return robot status.
 - `battery_level`
 - `is_charging`
 - `is_carrying_block`
-- `is_carrying_object`
-- `is_on_charger_platform`
-- `is_cliff_detected`
+- `is_on_charger`
 - `is_picked_up`
+
+**Known issue (#90):** Previous versions returned `is_carrying_object`, `is_on_charger_platform`, and `is_cliff_detected` which are not valid SDK properties. These have been removed. See `docs/investigations/ISSUE_90_STATUS_TOOLS_CONTRACT.md` for the authoritative SDK contract.
 
 ---
 
@@ -111,7 +111,9 @@ Return charger and battery state.
 **Output fields:**
 - `is_charging`
 - `battery_level`
-- `is_on_charger_platform`
+- `is_on_charger`
+
+**Known issue (#90):** Previous versions returned `is_on_charger_platform` which is not a valid SDK property. Changed to `is_on_charger`.
 
 ---
 
@@ -377,6 +379,6 @@ Execute one command at a time and wait for explicit confirmation before proceedi
 - [ ] `vector_capture_image` — Returns valid JPEG base64 payload
 - [ ] `vector_face_detection` — Returns `face_count` and `faces` array
 - [ ] `vector_vision_reset` — All vision modes disabled; confirm no active vision LED
-- [ ] `vector_charger_status` — Returns `is_charging`, `battery_level`, `is_on_charger_platform`
+- [ ] `vector_charger_status` — Returns `is_charging`, `battery_level`, `is_on_charger`
 - [ ] `vector_touch_status` — Returns `is_being_touched`, `raw_touch_value`; verify by touching/not touching sensor
 - [ ] `vector_proximity_status` — Returns `distance_mm`, `found_object`, `is_lift_in_fov`; verify by placing/removing object

--- a/docs/investigations/ISSUE_90_STATUS_TOOLS_CONTRACT.md
+++ b/docs/investigations/ISSUE_90_STATUS_TOOLS_CONTRACT.md
@@ -1,0 +1,175 @@
+# Issue #90: Status Tools SDK Contract Alignment
+
+**Status:** Investigation complete
+**Created:** 2026-02-28
+**Issue:** https://github.com/danmartinez78/VectorClaw/issues/90
+
+---
+
+## Problem
+
+VectorClaw status tools assume status attributes that are not guaranteed in the SDK's `RobotStatus` class:
+
+- `is_carrying_object` → NOT a valid property
+- `is_on_charger_platform` → NOT a valid property
+- `is_cliff_detected` → NOT a valid property
+
+These were accessed via `getattr()` with fallback to `None`, which masks the contract mismatch instead of addressing it.
+
+---
+
+## Authoritative SDK Contract
+
+**Source:** `anki_vector.status.RobotStatus` class
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `are_motors_moving` | bool | Any motor (head, lift, wheels) active |
+| `is_carrying_block` | bool | Robot carrying cube/block |
+| `is_docking_to_marker` | bool | Heading toward marker (charger/cube) |
+| `is_picked_up` | bool | Robot in air (not on stable surface) |
+| `is_button_pressed` | bool | Button pressed |
+| `is_falling` | bool | Robot falling |
+| `is_animating` | bool | Animation playing |
+| `is_pathing` | bool | Path planning active |
+| `is_lift_in_pos` | bool | Lift at target position |
+| `is_head_in_pos` | bool | Head at target position |
+| `is_in_calm_power_mode` | bool | Low power mode |
+| `is_on_charger` | bool | On charger platform |
+| `is_charging` | bool | Actively charging |
+
+**NOT in RobotStatus:**
+- ~~`is_carrying_object`~~ → Use `is_carrying_block`
+- ~~`is_on_charger_platform`~~ → Use `is_on_charger`
+- ~~`is_cliff_detected`~~ → Not available via RobotStatus
+
+---
+
+## Current Implementation Issues
+
+### `vector_status()` (tools_perception.py)
+
+```python
+def vector_status() -> dict:
+    robot = _robot()
+    battery = robot.get_battery_state()
+    st = robot.status
+    return {
+        "status": "ok",
+        "battery_level": battery.battery_level,
+        "is_charging": st.is_charging,                              # ✅ Valid
+        "is_carrying_block": st.is_carrying_block,                  # ✅ Valid
+        "is_carrying_object": getattr(st, "is_carrying_object", None),   # ❌ Invalid
+        "is_on_charger_platform": getattr(st, "is_on_charger_platform", None),  # ❌ Invalid
+        "is_cliff_detected": getattr(st, "is_cliff_detected", None),  # ❌ Invalid
+        "is_picked_up": getattr(st, "is_picked_up", None),           # ⚠️ Valid but using getattr
+    }
+```
+
+### `vector_charger_status()` (tools_perception.py)
+
+```python
+def vector_charger_status() -> dict:
+    ...
+    return {
+        ...
+        "is_on_charger_platform": robot.status.is_on_charger_platform,  # ❌ Will raise AttributeError
+    }
+```
+
+**Note:** The hardware smoke test showed `vector_charger_status` FAIL with attribute error, confirming this issue.
+
+---
+
+## Recommended Fix
+
+### Option A: Strict Contract (Recommended)
+
+Remove invalid fields, use only authoritative SDK properties:
+
+```python
+def vector_status() -> dict:
+    robot = _robot()
+    battery = robot.get_battery_state()
+    st = robot.status
+    return {
+        "status": "ok",
+        "battery_level": battery.battery_level,
+        "is_charging": st.is_charging,
+        "is_carrying_block": st.is_carrying_block,
+        "is_on_charger": st.is_on_charger,
+        "is_picked_up": st.is_picked_up,
+    }
+```
+
+**Pros:**
+- Clean contract, no assumptions
+- Fails fast on SDK changes (good for detection)
+- Matches hardware reality
+
+**Cons:**
+- Breaking change if external tools depend on old field names
+- `is_cliff_detected` not available (but wasn't working anyway)
+
+### Option B: Defensive with Warnings
+
+Keep `getattr()` but log warnings for missing fields:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def vector_status() -> dict:
+    ...
+    is_cliff = getattr(st, "is_cliff_detected", None)
+    if is_cliff is None:
+        logger.warning("is_cliff_detected not available in RobotStatus")
+    ...
+```
+
+**Pros:**
+- Non-breaking for consumers
+- Visibility into contract drift
+
+**Cons:**
+- Masks the real problem
+- Log noise
+
+---
+
+## Implementation Plan
+
+1. **Update `vector_status()`**:
+   - Remove `is_carrying_object` (use `is_carrying_block`)
+   - Remove `is_on_charger_platform` (use `is_on_charger`)
+   - Remove `is_cliff_detected` (not available)
+   - Remove `getattr()` for valid properties
+
+2. **Update `vector_charger_status()`**:
+   - Change `is_on_charger_platform` → `is_on_charger`
+
+3. **Update API docs**:
+   - Document authoritative field names
+   - Note breaking change if applicable
+
+4. **Add tests**:
+   - Mock RobotStatus with valid properties only
+   - Assert no AttributeError on status tool calls
+
+---
+
+## Test Evidence
+
+**Hardware smoke (2026-02-27):**
+- `vector_status`: FAIL → PASS after hotfix (bcee0db)
+- `vector_charger_status`: FAIL (not fixed yet)
+
+The hotfix added `getattr()` fallbacks, but this is a bandage. The real fix is using correct property names.
+
+---
+
+## References
+
+- SDK source: `anki_vector/status.py`
+- Hardware smoke log: `docs/HARDWARE_SMOKE_LOG.md`
+- Issue: https://github.com/danmartinez78/VectorClaw/issues/90


### PR DESCRIPTION
## Summary

Investigates issue #90: status tools assume invalid SDK attributes.

## Root Cause

VectorClaw status tools use field names that don't exist in `anki_vector.status.RobotStatus`:
- `is_carrying_object` → should be `is_carrying_block`
- `is_on_charger_platform` → should be `is_on_charger`
- `is_cliff_detected` → not available in RobotStatus

This caused `vector_charger_status` to crash during hardware smoke testing.

## Changes

- **Investigation doc:** `docs/investigations/ISSUE_90_STATUS_TOOLS_CONTRACT.md`
  - Documents authoritative SDK property list (13 properties)
  - Identifies invalid fields with correct replacements
  - Recommends Option A: strict contract compliance

- **API reference updates:**
  - `vector_status`: Remove invalid fields, use `is_on_charger`
  - `vector_charger_status`: Change to `is_on_charger`
  - Add known issue notes

## Breaking Change

External consumers expecting `is_on_charger_platform` will need to update to `is_on_charger`.

## Related

- Closes #90 (investigation phase)
- Follow-up PR: implement code fix in tools_perception.py
- Related: #85 (schema validation), hardware smoke findings